### PR TITLE
Fix typo in .Rbuildignore blocking doc&install

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,5 +14,5 @@
 ^\.bumpversion\.cfg$
 ^\.editorconfig$
 ^\.lintr$
-^\Makefile$
+^Makefile$
 


### PR DESCRIPTION
Change "^\Makefile$" -> "^Makefile$" (remove backslash)